### PR TITLE
#78 Test with Exasol v8

### DIFF
--- a/.busted
+++ b/.busted
@@ -25,7 +25,7 @@ return {
     ["repeat"] = 20
   },
   smoketest = {
-    tags = {"smoketest"}
+    ROOT = {"spec/integration/smoketest_spec.lua"},
   },
   utest = {
     ROOT = {"spec/unit"},

--- a/.github/workflows/broken_links_checker.yml
+++ b/.github/workflows/broken_links_checker.yml
@@ -19,7 +19,10 @@ jobs:
       - name: Configure broken links checker
         run: |
           mkdir -p ./target
-          echo '{ "aliveStatusCodes": [429, 200], "ignorePatterns": [{"pattern": "^https?://(www.)?opensource.org"}] }' > ./target/broken_links_checker.json
+          echo '{"aliveStatusCodes": [429, 200], "ignorePatterns": [' \
+               '{"pattern": "^https?://(www|dev).mysql.com/"},' \
+               '{"pattern": "^https?://(www.)?opensource.org"}' \
+               ']}' > ./target/broken_links_checker.json
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: 'yes'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,11 +113,11 @@ jobs:
           path: target/luacov-reports/*
 
       - name: Validate tools
-        if: ${{ env.DEFAULT_DB_VERSION == matrix.exasol_version }}
+        if: ${{ always() && env.DEFAULT_DB_VERSION == matrix.exasol_version }}
         run: shellcheck --check-sourced --severity=style tools/*.sh
 
       - name: Run static code analysis
-        if: ${{ env.DEFAULT_DB_VERSION == matrix.exasol_version }}
+        if: ${{ always() && env.DEFAULT_DB_VERSION == matrix.exasol_version }}
         run: |
           eval $(luarocks path)
           tools/runluacheck.sh
@@ -129,6 +129,7 @@ jobs:
           java-version: "11"
           distribution: "temurin"
       - name: Trace requirements
+        if: ${{ env.DEFAULT_DB_VERSION == matrix.exasol_version }}
         run: ./tools/trace-requirements.sh
 
   ## This is a separate job because it requires running apt-get which takes > 40s.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,9 @@ jobs:
       fail-fast: true
       matrix:
         lua_version: ["5.4"]
-        exasol_version: ["7.1.19"] # Exasol v8 ("prerelease-8.17.0") will be added in https://github.com/exasol/exasol-driver-lua/issues/78
+        exasol_version: ["7.1.17"] # Exasol v8 ("prerelease-8.17.0") will be added in https://github.com/exasol/exasol-driver-lua/issues/78
     env:
-      DEFAULT_DB_VERSION: "7.1.19"
+      DEFAULT_DB_VERSION: "7.1.17"
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-lua-${{ matrix.lua_version }}-exasol-${{ matrix.exasol_version }}
       cancel-in-progress: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,9 @@ jobs:
       fail-fast: true
       matrix:
         lua_version: ["5.4"]
-        exasol_version: ["7.1.10", "prerelease-8.17.0"]
+        exasol_version: ["7.1.19", "prerelease-8.17.0"]
+    env:
+      DEFAULT_DB_VERSION: "7.1.19"
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-lua-${{ matrix.lua_version }}-exasol-${{ matrix.exasol_version }}
       cancel-in-progress: true
@@ -66,9 +68,11 @@ jobs:
           EXASOL_HOST=dummy LOG_LEVEL=TRACE luarocks test --local -- --run=smoketest
 
       - name: Build API documentation
+        if: ${{ env.DEFAULT_DB_VERSION == matrix.exasol_version }}
         run: ./tools/build-docs.sh
 
       - name: Upload API documentation
+        if: ${{ env.DEFAULT_DB_VERSION == matrix.exasol_version }}
         uses: actions/upload-artifact@v3
         with:
           name: api-documentation
@@ -102,22 +106,24 @@ jobs:
             tools/runtests.sh --run=ci
 
       - name: Archive code coverage results
+        if: ${{ env.DEFAULT_DB_VERSION == matrix.exasol_version }}
         uses: actions/upload-artifact@v3
         with:
           name: luacov-report
           path: target/luacov-reports/*
 
       - name: Validate tools
-        if: ${{ always() }}
+        if: ${{ env.DEFAULT_DB_VERSION == matrix.exasol_version }}
         run: shellcheck --check-sourced --severity=style tools/*.sh
 
       - name: Run static code analysis
-        if: ${{ always() }}
+        if: ${{ env.DEFAULT_DB_VERSION == matrix.exasol_version }}
         run: |
           eval $(luarocks path)
           tools/runluacheck.sh
 
       - name: "Set up JDK"
+        if: ${{ env.DEFAULT_DB_VERSION == matrix.exasol_version }}
         uses: actions/setup-java@v3
         with:
           java-version: "11"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: true
       matrix:
         lua_version: ["5.4"]
-        exasol_version: ["7.1.19", "prerelease-8.17.0"]
+        exasol_version: ["7.1.19"] # Exasol v8 ("prerelease-8.17.0") will be added in https://github.com/exasol/exasol-driver-lua/issues/78
     env:
       DEFAULT_DB_VERSION: "7.1.19"
     concurrency:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,10 @@ jobs:
 
   build:
     strategy:
-       fail-fast: true
-       matrix:
-          lua_version: [5.4]
-          exasol_version: [7.1.10]
+      fail-fast: true
+      matrix:
+        lua_version: ["5.4"]
+        exasol_version: ["7.1.10", "prerelease-8.17.0"]
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-lua-${{ matrix.lua_version }}-exasol-${{ matrix.exasol_version }}
       cancel-in-progress: true
@@ -24,9 +24,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-          repository: 'exasol/integration-test-docker-environment'
-          path: 'integration-test-docker-environment'
-          ref: '1.1.0'
+          repository: "exasol/integration-test-docker-environment"
+          path: "integration-test-docker-environment"
+          ref: "1.5.0"
 
       - name: Cache local Luarocks repository
         uses: actions/cache@v3
@@ -64,7 +64,7 @@ jobs:
         run: |
           eval $(luarocks path)
           EXASOL_HOST=dummy LOG_LEVEL=TRACE luarocks test --local -- --run=smoketest
-      
+
       - name: Build API documentation
         run: ./tools/build-docs.sh
 
@@ -102,7 +102,7 @@ jobs:
             tools/runtests.sh --run=ci
 
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: luacov-report
           path: target/luacov-reports/*
@@ -120,8 +120,8 @@ jobs:
       - name: "Set up JDK"
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
-          distribution: 'temurin'
+          java-version: "11"
+          distribution: "temurin"
       - name: Trace requirements
         run: ./tools/trace-requirements.sh
 
@@ -129,7 +129,7 @@ jobs:
   ## When the other job also uses apt-get this can be moved back.
   plantuml:
     strategy:
-       fail-fast: true
+      fail-fast: true
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/publish-api-doc.yml
+++ b/.github/workflows/publish-api-doc.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Lua
         uses: leafo/gh-actions-lua@v8
         with:
-          luaVersion: 5.4
+          luaVersion: "5.4"
 
       - name: Install LuaRocks
         uses: leafo/gh-actions-luarocks@v4

--- a/doc/changes/changelog.md
+++ b/doc/changes/changelog.md
@@ -1,4 +1,5 @@
 # Changelog
 
+* [0.2.1](changes_0.2.1.md)
 * [0.2.0](changes_0.2.0.md)
 * [0.1.0](changes_0.1.0.md)

--- a/doc/changes/changes_0.2.1.md
+++ b/doc/changes/changes_0.2.1.md
@@ -1,0 +1,11 @@
+# exasol-driver-lua 0.2.0, released 2023-??-??
+
+Code name: Upgrade to Exasol 8
+
+## Summary
+
+This release updates integration tests to additionally use a prerelease version of Exasol 8.
+
+## Tests
+
+* #78: Added tests with Exasol 8

--- a/doc/user_guide/user_guide.md
+++ b/doc/user_guide/user_guide.md
@@ -1,6 +1,6 @@
 # exasol-driver-lua – User Guide
 
-The Exasol Driver for Lua allows you to execute queries on an Exasol database and retrieve the results. This user-guide shows how to use the driver.
+The Exasol Driver for Lua (EDL) allows you to execute queries on an Exasol database and retrieve the results. This user-guide shows how to use the driver.
 
 ## Installing the Driver and Dependencies
 
@@ -283,3 +283,13 @@ To build such a package follow these steps:
     ```
 
 See files [amalg_util.lua](../../spec/amalg_util.lua) and [udf_spec.lua](../../spec/integration/udf_spec.lua) as an example how to automate this process.
+
+## Compatibility
+
+EDL is tested with the following Exasol versions:
+
+| EDL version | Exasol version    | Note                                    |
+|-------------|-------------------|-----------------------------------------|
+| 0.2.0       | 7.1.10            |                                         |
+| 0.2.1       | 7.1.19            |                                         |
+| 0.2.1       | prerelease-8.17.0 | supports TLS 1.3 and running EDL as UDF |

--- a/doc/user_guide/user_guide.md
+++ b/doc/user_guide/user_guide.md
@@ -147,7 +147,7 @@ When creating a new connection you can specify the following properties:
   * `tlsv1`
   * `tlsv1_1`
   * `tlsv1_2` (default)
-  * `tlsv1_3`
+  * `tlsv1_3` (only supported with Exasol v8 and later)
 * `tls_options` specifies additional options for OpenSSL, e.g. `no_tlsv1`. The default value is `all`. You can get a complete list of supported options by executing the following Lua code:
     ```lua
     require("ssl").config.options

--- a/doc/user_guide/user_guide.md
+++ b/doc/user_guide/user_guide.md
@@ -291,5 +291,5 @@ EDL is tested with the following Exasol versions:
 | EDL version | Exasol version    | Note                                    |
 |-------------|-------------------|-----------------------------------------|
 | 0.2.0       | 7.1.10            |                                         |
-| 0.2.1       | 7.1.19            |                                         |
+| 0.2.1       | 7.1.17            |                                         |
 | 0.2.1       | prerelease-8.17.0 | supports TLS 1.3 and running EDL as UDF |

--- a/luasql-exasol-0.2.1-1.rockspec
+++ b/luasql-exasol-0.2.1-1.rockspec
@@ -1,6 +1,6 @@
 rockspec_format = "3.0"
 
-local tag = "0.2.0"
+local tag = "0.2.1"
 
 package = "luasql-exasol"
 version = tag .. "-1"

--- a/spec/config.lua
+++ b/spec/config.lua
@@ -65,6 +65,10 @@ function M.db_supports_openssl_module()
     return M._is_exasol_8()
 end
 
+function M.db_supports_tlsv1_3()
+    return M._is_exasol_8()
+end
+
 local function starts_with(text, prefix)
     return text:find(prefix, 1, true) == 1
 end

--- a/spec/integration/Websocket_spec.lua
+++ b/spec/integration/Websocket_spec.lua
@@ -72,7 +72,11 @@ describe("Websocket", function()
 
     describe("with tls_protocol option", function()
         describe("connects successfully for value", function()
-            for _, tls_protocol_option in ipairs({"any", "tlsv1_2"}) do
+            local supported_protocols = {"any", "tlsv1_2"}
+            if config.db_supports_tlsv1_3() then
+                table.insert(supported_protocols, "tlsv1_3")
+            end
+            for _, tls_protocol_option in ipairs(supported_protocols) do
                 it(string.format("value %q", tls_protocol_option), function()
                     assert_connect_successful({tls_protocol = tls_protocol_option})
                 end)
@@ -80,7 +84,11 @@ describe("Websocket", function()
         end)
 
         describe("fails SSL negotiation for valid value", function()
-            for _, tls_protocol_option in ipairs({"tlsv1", "tlsv1_1", "tlsv1_3"}) do
+            local unsupported_protocols = {"tlsv1", "tlsv1_1"}
+            if not config.db_supports_tlsv1_3() then
+                table.insert(unsupported_protocols, "tlsv1_3")
+            end
+            for _, tls_protocol_option in ipairs(unsupported_protocols) do
                 it(string.format("%q", tls_protocol_option), function()
                     assert_connect_fails({tls_protocol = tls_protocol_option}, ssl_negotion_failed_error)
                 end)

--- a/src/luasql/exasol/ConnectionProperties.lua
+++ b/src/luasql/exasol/ConnectionProperties.lua
@@ -32,8 +32,8 @@ local ConnectionProperties = {}
 --
 -- * `tlsv1`
 -- * `tlsv1_1`
--- * `tlsv1_2`
--- * `tlsv1_3`
+-- * `tlsv1_2` (default)
+-- * `tlsv1_3` (only supported with Exasol v8 and later)
 --
 -- Run the following command to find out which TLS version your Exasol server supports:
 --

--- a/src/luasql/exasol/Websocket.lua
+++ b/src/luasql/exasol/Websocket.lua
@@ -47,6 +47,7 @@ local function connect_with_retry(url, websocket_options, remaining_retries)
         connection.data_handler:handle_data(conn, opcode, message)
     end, websocket_options)
     if err ~= nil then
+        wsclose(websocket)
         if remaining_retries <= 0 or not recoverable_connection_error(err) then
             ExaError:new("E-EDL-1", "Error connecting to {{url}}: {{error}}", {url = url, error = err}):raise()
         else

--- a/src/luasql/exasol/constants.lua
+++ b/src/luasql/exasol/constants.lua
@@ -5,7 +5,7 @@ local constants = {}
 local util = require("luasql.exasol.util")
 
 --- The version of this module
-constants.VERSION = "0.2.0-1"
+constants.VERSION = "0.2.1-1"
 
 --- The value returned by queries to indicate an SQL `NULL` value.
 constants.NULL = {}


### PR DESCRIPTION
This is part of #78. Due to https://github.com/exasol/integration-test-docker-environment/issues/190 ITDE fails parsing docker image version `prerelease-8.17.0`. That's why we can't enable testing with v8 yet.